### PR TITLE
Add background task system with progress tracking

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,9 @@
-from typing import List, Optional
+import asyncio
+import uuid
+from threading import Lock
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, BackgroundTasks, FastAPI, HTTPException, WebSocket
 from pydantic import BaseModel
 
 from excludarr.services.radarr_service import RadarrService
@@ -52,56 +55,167 @@ class Provider(BaseModel):
     clear_name: str
 
 
+class TaskInfo(BaseModel):
+    task_id: str
+
+
+class TaskStatus(BaseModel):
+    status: str
+    progress: float
+    result: Optional[Dict[str, Any]] = None
+
+
+class TaskManager:
+    def __init__(self) -> None:
+        self.tasks: Dict[str, Dict[str, Any]] = {}
+        self.lock = Lock()
+
+    def create(self) -> str:
+        task_id = str(uuid.uuid4())
+        with self.lock:
+            self.tasks[task_id] = {"status": "pending", "progress": 0.0, "result": None}
+        return task_id
+
+    def update(self, task_id: str, **kwargs: Any) -> None:
+        with self.lock:
+            self.tasks[task_id].update(kwargs)
+
+    def get(self, task_id: str) -> Optional[Dict[str, Any]]:
+        with self.lock:
+            return self.tasks.get(task_id)
+
+
 app = FastAPI()
 config = Config()
+task_manager = TaskManager()
 
 radarr_router = APIRouter(prefix="/radarr", tags=["radarr"])
 
 
-@radarr_router.post("/exclude", response_model=ExcludeResponse)
-def radarr_exclude(payload: RadarrExcludeRequest) -> ExcludeResponse:
-    service = RadarrService(config)
-    movies = service.get_movies_to_exclude(
-        payload.providers, payload.action, payload.disable_progress
-    )
-    result = service.exclude_movies(
-        movies, payload.action, payload.delete_files, payload.exclusion, yes=True
-    )
-    return ExcludeResponse(**result)
+def run_radarr_exclude(task_id: str, payload: RadarrExcludeRequest) -> None:
+    task_manager.update(task_id, status="running")
+    try:
+        service = RadarrService(config)
+
+        def progress_cb(current: int, total: int) -> None:
+            task_manager.update(task_id, progress=0.9 * current / total)
+
+        movies = service.get_movies_to_exclude(
+            payload.providers,
+            payload.action,
+            payload.disable_progress,
+            progress_cb=progress_cb,
+        )
+        result = service.exclude_movies(
+            movies, payload.action, payload.delete_files, payload.exclusion, yes=True
+        )
+        task_manager.update(task_id, status="completed", progress=1.0, result=result)
+    except Exception as exc:  # pragma: no cover - best effort logging
+        task_manager.update(
+            task_id, status="failed", progress=1.0, result={"error": str(exc)}
+        )
 
 
-@radarr_router.post("/re-add", response_model=ReAddResponse)
-def radarr_re_add(payload: RadarrReAddRequest) -> ReAddResponse:
-    service = RadarrService(config)
-    movies = service.get_movies_to_re_add(payload.providers, payload.disable_progress)
-    result = service.readd_movies(movies, yes=True)
-    return ReAddResponse(**result)
+def run_radarr_re_add(task_id: str, payload: RadarrReAddRequest) -> None:
+    task_manager.update(task_id, status="running")
+    try:
+        service = RadarrService(config)
+
+        def progress_cb(current: int, total: int) -> None:
+            task_manager.update(task_id, progress=0.9 * current / total)
+
+        movies = service.get_movies_to_re_add(
+            payload.providers, payload.disable_progress, progress_cb=progress_cb
+        )
+        result = service.readd_movies(movies, yes=True)
+        task_manager.update(task_id, status="completed", progress=1.0, result=result)
+    except Exception as exc:  # pragma: no cover - best effort logging
+        task_manager.update(
+            task_id, status="failed", progress=1.0, result={"error": str(exc)}
+        )
+
+
+@radarr_router.post("/exclude", response_model=TaskInfo)
+async def radarr_exclude(
+    payload: RadarrExcludeRequest, background_tasks: BackgroundTasks
+) -> TaskInfo:
+    task_id = task_manager.create()
+    background_tasks.add_task(run_radarr_exclude, task_id, payload)
+    return TaskInfo(task_id=task_id)
+
+
+@radarr_router.post("/re-add", response_model=TaskInfo)
+async def radarr_re_add(
+    payload: RadarrReAddRequest, background_tasks: BackgroundTasks
+) -> TaskInfo:
+    task_id = task_manager.create()
+    background_tasks.add_task(run_radarr_re_add, task_id, payload)
+    return TaskInfo(task_id=task_id)
 
 
 sonarr_router = APIRouter(prefix="/sonarr", tags=["sonarr"])
 
 
-@sonarr_router.post("/exclude", response_model=ExcludeResponse)
-def sonarr_exclude(payload: SonarrExcludeRequest) -> ExcludeResponse:
-    service = SonarrService(config)
-    series = service.get_series_to_exclude(
-        payload.providers,
-        payload.action,
-        payload.delete_files,
-        payload.disable_progress,
-    )
-    result = service.exclude_series(
-        series, payload.action, payload.delete_files, payload.exclusion, yes=True
-    )
-    return ExcludeResponse(**result)
+def run_sonarr_exclude(task_id: str, payload: SonarrExcludeRequest) -> None:
+    task_manager.update(task_id, status="running")
+    try:
+        service = SonarrService(config)
+
+        def progress_cb(current: int, total: int) -> None:
+            task_manager.update(task_id, progress=0.9 * current / total)
+
+        series = service.get_series_to_exclude(
+            payload.providers,
+            payload.action,
+            payload.delete_files,
+            payload.disable_progress,
+            progress_cb=progress_cb,
+        )
+        result = service.exclude_series(
+            series, payload.action, payload.delete_files, payload.exclusion, yes=True
+        )
+        task_manager.update(task_id, status="completed", progress=1.0, result=result)
+    except Exception as exc:  # pragma: no cover
+        task_manager.update(
+            task_id, status="failed", progress=1.0, result={"error": str(exc)}
+        )
 
 
-@sonarr_router.post("/re-add", response_model=ReAddResponse)
-def sonarr_re_add(payload: SonarrReAddRequest) -> ReAddResponse:
-    service = SonarrService(config)
-    series = service.get_series_to_re_add(payload.providers, payload.disable_progress)
-    result = service.readd_series(series, yes=True)
-    return ReAddResponse(**result)
+def run_sonarr_re_add(task_id: str, payload: SonarrReAddRequest) -> None:
+    task_manager.update(task_id, status="running")
+    try:
+        service = SonarrService(config)
+
+        def progress_cb(current: int, total: int) -> None:
+            task_manager.update(task_id, progress=0.9 * current / total)
+
+        series = service.get_series_to_re_add(
+            payload.providers, payload.disable_progress, progress_cb=progress_cb
+        )
+        result = service.readd_series(series, yes=True)
+        task_manager.update(task_id, status="completed", progress=1.0, result=result)
+    except Exception as exc:  # pragma: no cover
+        task_manager.update(
+            task_id, status="failed", progress=1.0, result={"error": str(exc)}
+        )
+
+
+@sonarr_router.post("/exclude", response_model=TaskInfo)
+async def sonarr_exclude(
+    payload: SonarrExcludeRequest, background_tasks: BackgroundTasks
+) -> TaskInfo:
+    task_id = task_manager.create()
+    background_tasks.add_task(run_sonarr_exclude, task_id, payload)
+    return TaskInfo(task_id=task_id)
+
+
+@sonarr_router.post("/re-add", response_model=TaskInfo)
+async def sonarr_re_add(
+    payload: SonarrReAddRequest, background_tasks: BackgroundTasks
+) -> TaskInfo:
+    task_id = task_manager.create()
+    background_tasks.add_task(run_sonarr_re_add, task_id, payload)
+    return TaskInfo(task_id=task_id)
 
 
 providers_router = APIRouter(prefix="/providers", tags=["providers"])
@@ -120,3 +234,28 @@ def list_providers() -> List[Provider]:
 app.include_router(radarr_router)
 app.include_router(sonarr_router)
 app.include_router(providers_router)
+
+
+@app.get("/tasks/{task_id}", response_model=TaskStatus)
+def get_task(task_id: str) -> TaskStatus:
+    task = task_manager.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return TaskStatus(**task)
+
+
+@app.websocket("/ws/tasks/{task_id}")
+async def task_ws(websocket: WebSocket, task_id: str) -> None:
+    await websocket.accept()
+    try:
+        while True:
+            task = task_manager.get(task_id)
+            if not task:
+                await websocket.close()
+                break
+            await websocket.send_json(task)
+            if task["status"] in {"completed", "failed"}:
+                break
+            await asyncio.sleep(1)
+    finally:
+        await websocket.close()

--- a/excludarr/core/radarr_actions.py
+++ b/excludarr/core/radarr_actions.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 from loguru import logger
 from rich.progress import Progress
 from pyarr import RadarrAPI
@@ -75,7 +77,13 @@ class RadarrActions:
 
         return None, None
 
-    def get_movies_to_exclude(self, providers, fast=True, disable_progress=False):
+    def get_movies_to_exclude(
+        self,
+        providers,
+        fast: bool = True,
+        disable_progress: bool = False,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
+    ):
         exclude_movies = {}
 
         # Get all movies listed in Radarr
@@ -92,8 +100,9 @@ class RadarrActions:
         )
 
         progress = Progress(disable=disable_progress)
+        total = len(radarr_movies)
         with progress:
-            for movie in progress.track(radarr_movies):
+            for idx, movie in enumerate(progress.track(radarr_movies), start=1):
                 # Set the minimal base variables
                 radarr_id = movie["id"]
                 title = movie["title"]
@@ -141,9 +150,18 @@ class RadarrActions:
 
                         logger.debug(f"{title} is streaming on {', '.join(clear_names)}")
 
+                if progress_cb:
+                    progress_cb(idx, total)
+
         return exclude_movies
 
-    def get_movies_to_re_add(self, providers, fast=True, disable_progress=False):
+    def get_movies_to_re_add(
+        self,
+        providers,
+        fast: bool = True,
+        disable_progress: bool = False,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
+    ):
         re_add_movies = {}
 
         # Get all movies listed in Radarr and filter it to only include not monitored movies
@@ -161,8 +179,9 @@ class RadarrActions:
         )
 
         progress = Progress(disable=disable_progress)
+        total = len(radarr_not_monitored_movies)
         with progress:
-            for movie in progress.track(radarr_not_monitored_movies):
+            for idx, movie in enumerate(progress.track(radarr_not_monitored_movies), start=1):
                 # Set the minimal base variables
                 radarr_id = movie["id"]
                 title = movie["title"]
@@ -197,6 +216,9 @@ class RadarrActions:
                             }
                         )
                         logger.debug(f"{title} is not streaming on a configured provider")
+
+                if progress_cb:
+                    progress_cb(idx, total)
 
         return re_add_movies
 

--- a/excludarr/core/sonarr_actions.py
+++ b/excludarr/core/sonarr_actions.py
@@ -1,4 +1,6 @@
 from loguru import logger
+from typing import Callable, Optional
+
 from rich.progress import Progress
 from pyarr import SonarrAPI
 
@@ -160,7 +162,12 @@ class SonarrActions:
         return jw_id, jw_serie_data
 
     def get_series_to_exclude(
-        self, providers, fast=True, disable_progress=False, tmdb_api_key=None
+        self,
+        providers,
+        fast: bool = True,
+        disable_progress: bool = False,
+        tmdb_api_key=None,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
     ):
         exclude_series = {}
 
@@ -178,8 +185,9 @@ class SonarrActions:
         )
 
         progress = Progress(disable=disable_progress)
+        total = len(sonarr_series)
         with progress:
-            for serie in progress.track(sonarr_series):
+            for idx, serie in enumerate(progress.track(sonarr_series), start=1):
                 # Set the minimal base variables
                 sonarr_id = serie["id"]
                 title = serie["title"]
@@ -276,6 +284,9 @@ class SonarrActions:
                                     f"{title} S{season_number}E{episode_number} is streaming on {', '.join(providers_match)}"
                                 )
 
+                if progress_cb:
+                    progress_cb(idx, total)
+
         # Check if the full season could be excluded rather than seperate episodes
         for exclude_id, exclude_entry in exclude_series.items():
             sonarr_object = exclude_entry["sonarr_object"]
@@ -331,7 +342,14 @@ class SonarrActions:
 
         return exclude_series
 
-    def get_series_to_re_add(self, providers, fast=True, disable_progress=False, tmdb_api_key=None):
+    def get_series_to_re_add(
+        self,
+        providers,
+        fast: bool = True,
+        disable_progress: bool = False,
+        tmdb_api_key=None,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
+    ):
         re_add_series = {}
 
         # Setup TMDB if there is an API key provided
@@ -352,8 +370,9 @@ class SonarrActions:
         )
 
         progress = Progress(disable=disable_progress)
+        total = len(sonarr_series)
         with progress:
-            for serie in progress.track(sonarr_series):
+            for idx, serie in enumerate(progress.track(sonarr_series), start=1):
                 # Set the minimal base variables
                 sonarr_id = serie["id"]
                 title = serie["title"]
@@ -436,6 +455,9 @@ class SonarrActions:
                                 logger.debug(
                                     f"{title} S{season_number}E{episode_number} is not streaming on a configured provider"
                                 )
+
+                if progress_cb:
+                    progress_cb(idx, total)
 
         # Check if the full season could be excluded rather than seperate episodes
         for re_add_id, re_add_entry in re_add_series.items():

--- a/excludarr/services/radarr_service.py
+++ b/excludarr/services/radarr_service.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from loguru import logger
 
@@ -45,6 +45,7 @@ class RadarrService:
         providers: Optional[List[str]],
         action: Action,
         disable_progress: bool,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
     ) -> Dict[int, dict]:
         """Return the movies that can be excluded.
 
@@ -56,10 +57,10 @@ class RadarrService:
             providers = self.config.providers
 
         movies = self.actions.get_movies_to_exclude(
-        
             providers,
             self.config.fast_search,
             disable_progress,
+            progress_cb,
         )
 
         if action == Action.not_monitored:
@@ -82,6 +83,7 @@ class RadarrService:
         self,
         providers: Optional[List[str]],
         disable_progress: bool,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
     ) -> Dict[int, dict]:
         """Return the movies that can be re-added."""
 
@@ -89,7 +91,7 @@ class RadarrService:
             providers = self.config.providers
 
         movies = self.actions.get_movies_to_re_add(
-            providers, self.config.fast_search, disable_progress
+            providers, self.config.fast_search, disable_progress, progress_cb
         )
         movies = {
             id: values

--- a/excludarr/services/sonarr_service.py
+++ b/excludarr/services/sonarr_service.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from loguru import logger
 
@@ -36,6 +36,7 @@ class SonarrService:
         action: Action,
         delete_files: bool,
         disable_progress: bool,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
     ) -> Dict[int, dict]:
         if not providers:
             providers = self.config.providers
@@ -45,6 +46,7 @@ class SonarrService:
             self.config.fast_search,
             disable_progress,
             tmdb_api_key=self.config.tmdb_api_key,
+            progress_cb=progress_cb,
         )
 
         for _, values in series.items():
@@ -101,6 +103,7 @@ class SonarrService:
         self,
         providers: Optional[List[str]],
         disable_progress: bool,
+        progress_cb: Optional[Callable[[int, int], None]] = None,
     ) -> Dict[int, dict]:
         if not providers:
             providers = self.config.providers
@@ -110,6 +113,7 @@ class SonarrService:
             self.config.fast_search,
             disable_progress,
             tmdb_api_key=self.config.tmdb_api_key,
+            progress_cb=progress_cb,
         )
 
         for _, values in series.items():


### PR DESCRIPTION
## Summary
- add in-memory task manager and task APIs for background jobs
- execute Radarr and Sonarr exclude/re-add calls asynchronously with progress callbacks
- stream job status via GET `/tasks/{id}` and websocket `/ws/tasks/{id}`

## Testing
- `python -m py_compile excludarr/core/radarr_actions.py excludarr/core/sonarr_actions.py excludarr/services/radarr_service.py excludarr/services/sonarr_service.py api/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68968bdc9d48832bba2309d42869e577